### PR TITLE
Add monthly calendar view for batch schedules

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -217,6 +217,170 @@
   color: #92400e;
 }
 
+/* Calendar */
+.calendar-wrapper {
+  border: 1px solid #e5e7eb;
+}
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+.calendar-day-header {
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  background-color: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+.calendar-week {
+  border-bottom: 1px solid #e5e7eb;
+}
+.calendar-week:last-child {
+  border-bottom: none;
+}
+.calendar-day-numbers {
+  border-bottom: none;
+}
+.calendar-day {
+  padding: 0.375rem 0.5rem;
+  min-height: 1.75rem;
+  border-right: 1px solid #f3f4f6;
+}
+.calendar-day:last-child {
+  border-right: none;
+}
+.calendar-day-number {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #374151;
+}
+.calendar-day.today {
+  background-color: #fffbeb;
+}
+.calendar-day.today .calendar-day-number {
+  background-color: #f59e0b;
+  color: white;
+  border-radius: 9999px;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6875rem;
+}
+.calendar-day.other-month {
+  background-color: #f9fafb;
+}
+.calendar-day.other-month .calendar-day-number {
+  color: #d1d5db;
+}
+.calendar-bars {
+  position: relative;
+  margin: 0 0 0.25rem;
+}
+.calendar-bar {
+  position: absolute;
+  height: 20px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-decoration: none;
+  overflow: hidden;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  z-index: 1;
+}
+.calendar-bar:hover {
+  opacity: 0.85;
+  z-index: 2;
+}
+.calendar-bar-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.calendar-more {
+  position: absolute;
+  font-size: 0.625rem;
+  color: #9ca3af;
+  padding: 0 6px;
+  width: calc(100% / 7);
+}
+
+/* Mobile calendar */
+.calendar-grid-mobile {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  background-color: #e5e7eb;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+.calendar-day-header-mobile {
+  padding: 0.375rem;
+  text-align: center;
+  font-size: 0.625rem;
+  font-weight: 600;
+  color: #6b7280;
+  background-color: #f9fafb;
+}
+.calendar-day-mobile {
+  background-color: white;
+  padding: 0.25rem;
+  min-height: 3rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+  cursor: pointer;
+}
+.calendar-day-mobile.today {
+  background-color: #fffbeb;
+}
+.calendar-day-mobile.other-month {
+  background-color: #f9fafb;
+}
+.calendar-day-number-mobile {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: #374151;
+}
+.calendar-day-mobile.today .calendar-day-number-mobile {
+  background-color: #f59e0b;
+  color: white;
+  border-radius: 9999px;
+  width: 1.375rem;
+  height: 1.375rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.625rem;
+}
+.calendar-day-mobile.other-month .calendar-day-number-mobile {
+  color: #d1d5db;
+}
+.calendar-dots {
+  display: flex;
+  gap: 2px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.calendar-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+}
+.calendar-dot-more {
+  font-size: 0.5rem;
+  color: #9ca3af;
+  line-height: 1;
+}
+
 /* Modal overlay */
 .modal-overlay {
   position: fixed;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -100,6 +100,32 @@ function updateFilters(group, value) {
   window.location.href = url.toString();
 }
 
+// Calendar: navigate to a specific month
+function navigateCalendar(year, month) {
+  window.location.href = `/calendar?year=${year}&month=${month}`;
+}
+
+// Calendar: show day detail on mobile
+function showDayBatches(dateStr) {
+  if (typeof calendarDayBatches === 'undefined') return;
+  const batches = calendarDayBatches[dateStr] || [];
+  if (batches.length === 0) return;
+
+  const d = new Date(dateStr + 'T00:00:00');
+  const title = d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+  document.getElementById('dayModalTitle').textContent = title;
+
+  const list = document.getElementById('dayModalList');
+  list.innerHTML = batches.map(b =>
+    `<a href="/batches/${b.id}" class="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-50 text-sm text-gray-800 no-underline" style="text-decoration:none;">
+      <span style="background-color:${b.bgColor}; color:${b.textColor};" class="badge">${b.status}</span>
+      <span>${b.label}</span>
+    </a>`
+  ).join('');
+
+  document.getElementById('dayModal').style.display = '';
+}
+
 // Client-side search for lists
 function setupSearch(inputId, itemSelector) {
   const input = document.getElementById(inputId);

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -114,23 +114,29 @@ router.get('/calendar', (req, res) => {
     'harvest_start_date', 'harvest_end_date'
   ];
 
-  // A batch overlaps if its earliest date <= gridEnd AND its latest date >= gridStart
-  const minDateExpr = `MIN(${dateFields.map(f => `NULLIF(b.${f}, '')`).join(', ')})`;
-  const maxDateExpr = `MAX(${dateFields.map(f => `NULLIF(b.${f}, '')`).join(', ')})`;
-
-  const batches = db.prepare(`
+  // Query all batches that have at least one date, then compute spans in JS
+  // (SQLite's multi-arg MIN/MAX returns NULL if any arg is NULL, so we can't use it)
+  const allBatches = db.prepare(`
     SELECT b.*, v.name as variety_name, v.color as variety_color,
-           l.name as location_name,
-           ${minDateExpr} as earliest_date,
-           ${maxDateExpr} as latest_date
+           l.name as location_name
     FROM batches b
     LEFT JOIN varieties v ON b.variety_id = v.id
     LEFT JOIN locations l ON b.location_id = l.id
     WHERE (${dateFields.map(f => `b.${f} IS NOT NULL AND b.${f} != ''`).join(' OR ')})
-    GROUP BY b.id
-    HAVING earliest_date <= ? AND latest_date >= ?
-    ORDER BY earliest_date, v.name
-  `).all(gridEndStr, gridStartStr);
+    ORDER BY v.name
+  `).all();
+
+  // Compute earliest/latest dates and filter to visible window
+  const batches = allBatches.map(b => {
+    const dates = dateFields.map(f => b[f]).filter(d => d && d !== '');
+    if (dates.length === 0) return null;
+    dates.sort();
+    b.earliest_date = dates[0];
+    b.latest_date = dates[dates.length - 1];
+    return b;
+  }).filter(b => b && b.earliest_date <= gridEndStr && b.latest_date >= gridStartStr);
+
+  batches.sort((a, b) => a.earliest_date.localeCompare(b.earliest_date) || (a.variety_name || '').localeCompare(b.variety_name || ''));
 
   // Prev/next month params
   let prevMonth = month - 1, prevYear = year;

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -81,6 +81,76 @@ router.get('/locations/:id/edit', (req, res) => {
   res.render('locations/form', { location });
 });
 
+// Calendar view
+router.get('/calendar', (req, res) => {
+  const now = new Date();
+  let year = parseInt(req.query.year) || now.getFullYear();
+  let month = parseInt(req.query.month) || (now.getMonth() + 1);
+
+  // Clamp month and adjust year
+  if (month < 1) { month = 12; year--; }
+  if (month > 12) { month = 1; year++; }
+
+  // Calendar grid boundaries
+  const firstOfMonth = new Date(year, month - 1, 1);
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const startDayOfWeek = firstOfMonth.getDay(); // 0=Sun
+
+  // Visible window: include prev/next month overflow days
+  const gridStart = new Date(firstOfMonth);
+  gridStart.setDate(gridStart.getDate() - startDayOfWeek);
+  const totalCells = Math.ceil((startDayOfWeek + daysInMonth) / 7) * 7;
+  const gridEnd = new Date(gridStart);
+  gridEnd.setDate(gridEnd.getDate() + totalCells - 1);
+
+  const fmt = (d) => d.toISOString().slice(0, 10);
+  const gridStartStr = fmt(gridStart);
+  const gridEndStr = fmt(gridEnd);
+
+  // Query batches that overlap the visible window
+  const dateFields = [
+    'planned_seed_date', 'actual_seed_date', 'germination_date',
+    'transplant_date', 'first_bud_date', 'first_bloom_date',
+    'harvest_start_date', 'harvest_end_date'
+  ];
+
+  // A batch overlaps if its earliest date <= gridEnd AND its latest date >= gridStart
+  const minDateExpr = `MIN(${dateFields.map(f => `NULLIF(b.${f}, '')`).join(', ')})`;
+  const maxDateExpr = `MAX(${dateFields.map(f => `NULLIF(b.${f}, '')`).join(', ')})`;
+
+  const batches = db.prepare(`
+    SELECT b.*, v.name as variety_name, v.color as variety_color,
+           l.name as location_name,
+           ${minDateExpr} as earliest_date,
+           ${maxDateExpr} as latest_date
+    FROM batches b
+    LEFT JOIN varieties v ON b.variety_id = v.id
+    LEFT JOIN locations l ON b.location_id = l.id
+    WHERE (${dateFields.map(f => `b.${f} IS NOT NULL AND b.${f} != ''`).join(' OR ')})
+    GROUP BY b.id
+    HAVING earliest_date <= ? AND latest_date >= ?
+    ORDER BY earliest_date, v.name
+  `).all(gridEndStr, gridStartStr);
+
+  // Prev/next month params
+  let prevMonth = month - 1, prevYear = year;
+  if (prevMonth < 1) { prevMonth = 12; prevYear--; }
+  let nextMonth = month + 1, nextYear = year;
+  if (nextMonth > 12) { nextMonth = 1; nextYear++; }
+
+  const monthNames = ['January','February','March','April','May','June',
+                      'July','August','September','October','November','December'];
+
+  res.render('calendar', {
+    batches, year, month,
+    monthName: monthNames[month - 1],
+    daysInMonth, startDayOfWeek, totalCells,
+    gridStartStr, gridEndStr,
+    prevMonth, prevYear, nextMonth, nextYear,
+    today: fmt(now)
+  });
+});
+
 // Batches pages
 router.get('/batches', (req, res) => {
   const { status, variety_id, location_id, season, year } = req.query;

--- a/views/calendar.ejs
+++ b/views/calendar.ejs
@@ -1,0 +1,273 @@
+<%- include('header', { title: 'Calendar' }) %>
+
+<%
+  // Status-to-color mapping (matches badge classes)
+  const statusColors = {
+    planned:      { bg: '#e5e7eb', text: '#374151' },
+    seeded:       { bg: '#fef3c7', text: '#92400e' },
+    germinating:  { bg: '#d1fae5', text: '#065f46' },
+    growing:      { bg: '#a7f3d0', text: '#065f46' },
+    transplanted: { bg: '#bfdbfe', text: '#1e40af' },
+    budding:      { bg: '#e9d5ff', text: '#6b21a8' },
+    blooming:     { bg: '#fbcfe8', text: '#9d174d' },
+    harvesting:   { bg: '#fecaca', text: '#991b1b' },
+    done:         { bg: '#d1d5db', text: '#1f2937' }
+  };
+
+  // Build a map: dateStr -> [batch info]
+  const dayBatches = {};
+  const batchSpans = [];
+
+  batches.forEach(b => {
+    if (!b.earliest_date || !b.latest_date) return;
+
+    // Clamp to visible grid
+    const start = b.earliest_date < gridStartStr ? gridStartStr : b.earliest_date;
+    const end = b.latest_date > gridEndStr ? gridEndStr : b.latest_date;
+    const clippedLeft = b.earliest_date < gridStartStr;
+    const clippedRight = b.latest_date > gridEndStr;
+    const colors = statusColors[b.status] || statusColors.planned;
+
+    batchSpans.push({
+      id: b.id,
+      label: (b.variety_name || 'Unknown') + ' ' + b.batch_code,
+      start,
+      end,
+      clippedLeft,
+      clippedRight,
+      bgColor: colors.bg,
+      textColor: colors.text,
+      status: b.status
+    });
+
+    // Also populate per-day map for mobile dots
+    let d = new Date(start + 'T00:00:00');
+    const endD = new Date(end + 'T00:00:00');
+    while (d <= endD) {
+      const key = d.toISOString().slice(0, 10);
+      if (!dayBatches[key]) dayBatches[key] = [];
+      dayBatches[key].push({
+        id: b.id,
+        label: (b.variety_name || 'Unknown') + ' ' + b.batch_code,
+        bgColor: colors.bg,
+        textColor: colors.text,
+        status: b.status
+      });
+      d.setDate(d.getDate() + 1);
+    }
+  });
+
+  // Build calendar grid dates
+  const gridDates = [];
+  const gStart = new Date(gridStartStr + 'T00:00:00');
+  for (let i = 0; i < totalCells; i++) {
+    const d = new Date(gStart);
+    d.setDate(d.getDate() + i);
+    const dateStr = d.toISOString().slice(0, 10);
+    const dayMonth = d.getMonth() + 1;
+    gridDates.push({
+      date: dateStr,
+      day: d.getDate(),
+      isCurrentMonth: dayMonth === month,
+      isToday: dateStr === today
+    });
+  }
+
+  // For bar rendering: compute grid column positions
+  // Each date maps to a column index (0-based)
+  const dateToCol = {};
+  gridDates.forEach((gd, i) => {
+    dateToCol[gd.date] = i;
+  });
+
+  // Group bars by row in each week to handle stacking
+  const numWeeks = totalCells / 7;
+  const MAX_BARS_PER_DAY = 3;
+
+  // Assign a "lane" to each bar within each week-row
+  // A bar spans columns startCol..endCol within its week
+  // We process week by week
+  const weekBarAssignments = []; // array of weeks, each an array of { bar, lane, startCol, endCol }
+
+  for (let w = 0; w < numWeeks; w++) {
+    const weekStart = w * 7;
+    const weekEnd = weekStart + 6;
+    const assignments = [];
+    const lanes = []; // lanes[lane] = last occupied column in that lane
+
+    batchSpans.forEach(bar => {
+      const barStartCol = dateToCol[bar.start];
+      const barEndCol = dateToCol[bar.end];
+      if (barStartCol === undefined || barEndCol === undefined) return;
+
+      // Does this bar intersect this week?
+      if (barEndCol < weekStart || barStartCol > weekEnd) return;
+
+      const clampedStart = Math.max(barStartCol, weekStart);
+      const clampedEnd = Math.min(barEndCol, weekEnd);
+      const relStart = clampedStart - weekStart; // 0-6
+      const relEnd = clampedEnd - weekStart; // 0-6
+
+      // Find first available lane
+      let lane = -1;
+      for (let l = 0; l < lanes.length; l++) {
+        if (lanes[l] < relStart) {
+          lane = l;
+          break;
+        }
+      }
+      if (lane === -1) {
+        lane = lanes.length;
+        lanes.push(-1);
+      }
+      lanes[lane] = relEnd;
+
+      assignments.push({
+        bar,
+        lane,
+        relStart,
+        relEnd,
+        clippedLeft: bar.clippedLeft && barStartCol < weekStart,
+        clippedRight: bar.clippedRight && barEndCol > weekEnd
+      });
+    });
+
+    weekBarAssignments.push(assignments);
+  }
+%>
+
+<!-- Calendar header -->
+<div class="flex items-center justify-between mb-4">
+  <h1 class="text-2xl font-bold text-gray-800"><%= monthName %> <%= year %></h1>
+  <div class="flex items-center gap-2">
+    <a href="/calendar?year=<%= prevYear %>&month=<%= prevMonth %>"
+       class="btn btn-secondary btn-sm" title="Previous month">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+    </a>
+    <a href="/calendar" class="btn btn-secondary btn-sm">Today</a>
+    <a href="/calendar?year=<%= nextYear %>&month=<%= nextMonth %>"
+       class="btn btn-secondary btn-sm" title="Next month">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+    </a>
+  </div>
+</div>
+
+<!-- Desktop calendar -->
+<div class="calendar-wrapper hidden md:block card p-0 overflow-hidden">
+  <!-- Day of week headers -->
+  <div class="calendar-grid">
+    <% ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].forEach(d => { %>
+      <div class="calendar-day-header"><%= d %></div>
+    <% }) %>
+  </div>
+
+  <!-- Week rows with bars -->
+  <% for (let w = 0; w < numWeeks; w++) {
+    const weekAssignments = weekBarAssignments[w];
+    const maxLane = weekAssignments.reduce((m, a) => Math.max(m, a.lane), -1);
+    const visibleLanes = Math.min(maxLane + 1, MAX_BARS_PER_DAY);
+    const overflowByDay = {};
+
+    // Count overflow per day
+    for (let d = 0; d < 7; d++) {
+      const barsInDay = weekAssignments.filter(a => a.relStart <= d && a.relEnd >= d);
+      if (barsInDay.length > MAX_BARS_PER_DAY) {
+        overflowByDay[d] = barsInDay.length - MAX_BARS_PER_DAY;
+      }
+    }
+  %>
+    <div class="calendar-week">
+      <!-- Day number cells -->
+      <div class="calendar-grid calendar-day-numbers">
+        <% for (let d = 0; d < 7; d++) {
+          const gd = gridDates[w * 7 + d];
+        %>
+          <div class="calendar-day <%= gd.isToday ? 'today' : '' %> <%= !gd.isCurrentMonth ? 'other-month' : '' %>">
+            <span class="calendar-day-number"><%= gd.day %></span>
+          </div>
+        <% } %>
+      </div>
+
+      <!-- Bars area -->
+      <div class="calendar-bars" style="height: <%= Math.max(visibleLanes, 0) * 24 + (Object.keys(overflowByDay).length > 0 ? 18 : 0) %>px">
+        <% weekAssignments.forEach(a => {
+          if (a.lane >= MAX_BARS_PER_DAY) return;
+          const leftPct = (a.relStart / 7 * 100).toFixed(2);
+          const widthPct = ((a.relEnd - a.relStart + 1) / 7 * 100).toFixed(2);
+          const topPx = a.lane * 24;
+        %>
+          <a href="/batches/<%= a.bar.id %>"
+             class="calendar-bar"
+             style="left:<%= leftPct %>%; width:<%= widthPct %>%; top:<%= topPx %>px; background-color:<%= a.bar.bgColor %>; color:<%= a.bar.textColor %>;"
+             title="<%= a.bar.label %> (<%= a.bar.status %>)">
+            <span class="calendar-bar-label"><%= a.bar.label %></span>
+          </a>
+        <% }) %>
+
+        <!-- Overflow indicators -->
+        <% Object.entries(overflowByDay).forEach(([d, count]) => {
+          const leftPct = (parseInt(d) / 7 * 100).toFixed(2);
+        %>
+          <div class="calendar-more"
+               style="left:<%= leftPct %>%; top:<%= visibleLanes * 24 %>px;">
+            +<%= count %> more
+          </div>
+        <% }) %>
+      </div>
+    </div>
+  <% } %>
+</div>
+
+<!-- Mobile calendar -->
+<div class="md:hidden">
+  <div class="calendar-grid-mobile">
+    <% ['S','M','T','W','T','F','S'].forEach(d => { %>
+      <div class="calendar-day-header-mobile"><%= d %></div>
+    <% }) %>
+
+    <% gridDates.forEach(gd => {
+      const batchesForDay = dayBatches[gd.date] || [];
+    %>
+      <div class="calendar-day-mobile <%= gd.isToday ? 'today' : '' %> <%= !gd.isCurrentMonth ? 'other-month' : '' %>"
+           <% if (batchesForDay.length > 0) { %>onclick="showDayBatches('<%= gd.date %>')"<% } %>>
+        <span class="calendar-day-number-mobile"><%= gd.day %></span>
+        <% if (batchesForDay.length > 0) { %>
+          <div class="calendar-dots">
+            <% batchesForDay.slice(0, 3).forEach(b => { %>
+              <span class="calendar-dot" style="background-color:<%= b.bgColor %>"></span>
+            <% }) %>
+            <% if (batchesForDay.length > 3) { %>
+              <span class="calendar-dot-more">+<%= batchesForDay.length - 3 %></span>
+            <% } %>
+          </div>
+        <% } %>
+      </div>
+    <% }) %>
+  </div>
+</div>
+
+<!-- Mobile day detail modal (hidden by default) -->
+<div id="dayModal" class="modal-overlay" style="display:none" onclick="if(event.target===this)this.style.display='none'">
+  <div class="modal-content" style="max-width:24rem;">
+    <div class="flex items-center justify-between mb-3">
+      <h3 id="dayModalTitle" class="font-bold text-gray-800"></h3>
+      <button onclick="document.getElementById('dayModal').style.display='none'" class="text-gray-400 hover:text-gray-600">&times;</button>
+    </div>
+    <div id="dayModalList" class="flex flex-col gap-2"></div>
+  </div>
+</div>
+
+<!-- Data for mobile day detail -->
+<script>
+  var calendarDayBatches = <%- JSON.stringify(dayBatches) %>;
+</script>
+
+<% if (batches.length === 0) { %>
+  <div class="empty-state mt-8">
+    <div class="empty-state-icon">&#128197;</div>
+    <p class="text-gray-500 mb-2">No batches with dates in <%= monthName %> <%= year %></p>
+    <a href="/batches/new" class="btn btn-primary">+ New Batch</a>
+  </div>
+<% } %>
+
+<%- include('footer') %>

--- a/views/footer.ejs
+++ b/views/footer.ejs
@@ -15,6 +15,10 @@
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
         <span>Locations</span>
       </a>
+      <a href="/calendar" class="mobile-nav-link <%= currentPath.startsWith('/calendar') ? 'mobile-nav-active' : '' %>">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke-width="2"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 2v4M8 2v4M3 10h18"/></svg>
+        <span>Calendar</span>
+      </a>
       <a href="/batches" class="mobile-nav-link <%= currentPath.startsWith('/batches') ? 'mobile-nav-active' : '' %>">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/></svg>
         <span>Batches</span>

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -21,6 +21,7 @@
         <a href="/" class="nav-link <%= currentPath === '/' ? 'nav-active' : '' %>">Dashboard</a>
         <a href="/varieties" class="nav-link <%= currentPath.startsWith('/varieties') ? 'nav-active' : '' %>">Varieties</a>
         <a href="/locations" class="nav-link <%= currentPath.startsWith('/locations') ? 'nav-active' : '' %>">Locations</a>
+        <a href="/calendar" class="nav-link <%= currentPath.startsWith('/calendar') ? 'nav-active' : '' %>">Calendar</a>
         <a href="/batches" class="nav-link <%= currentPath.startsWith('/batches') ? 'nav-active' : '' %>">Batches</a>
       </nav>
 


### PR DESCRIPTION
## Summary

- Adds a `/calendar` page with a monthly grid showing batch lifecycle events as colored horizontal bars spanning their date ranges
- Bars are color-coded by batch status (reusing existing badge colors), labeled with variety name + batch code, and link to batch detail pages
- Supports month-by-month navigation with prev/next arrows and a "Today" button
- Mobile layout uses compact colored dots per day with a tap-to-reveal modal listing that day's batches
- Calendar link added to both desktop nav (between Locations and Batches) and mobile bottom nav

Closes #1

## Test plan

- [x] Navigate to `/calendar` — should show current month with day grid and today highlighted
- [x] Create batches with various date ranges — bars should span the correct days
- [x] Click prev/next arrows — should navigate months correctly
- [x] Click a batch bar — should navigate to batch detail page
- [x] Check on mobile viewport — should show dots with tap-to-reveal modal
- [x] Verify Calendar appears in both desktop and mobile navigation
- [x] Test with batches spanning multiple months — bars should clip at month boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)