### PR TITLE
Add growing notes fields and batch date filters

### DIFF
--- a/db/database.js
+++ b/db/database.js
@@ -16,4 +16,21 @@ db.pragma('foreign_keys = ON');
 const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8');
 db.exec(schema);
 
+// Migrations for existing databases
+const varietyMigrationColumns = [
+  'temperature_notes TEXT',
+  'light_notes TEXT',
+  'transplanting_notes TEXT',
+  'soil_notes TEXT',
+  'moisture_notes TEXT',
+  'tray_type_notes TEXT'
+];
+for (const col of varietyMigrationColumns) {
+  try {
+    db.exec(`ALTER TABLE varieties ADD COLUMN ${col}`);
+  } catch (e) {
+    // Column already exists
+  }
+}
+
 module.exports = db;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -19,6 +19,12 @@ CREATE TABLE IF NOT EXISTS varieties (
   spacing_inches INTEGER,
   light_requirement TEXT,
   pinch INTEGER DEFAULT 0,
+  temperature_notes TEXT,
+  light_notes TEXT,
+  transplanting_notes TEXT,
+  soil_notes TEXT,
+  moisture_notes TEXT,
+  tray_type_notes TEXT,
   notes TEXT,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP

--- a/routes/batches.js
+++ b/routes/batches.js
@@ -41,7 +41,7 @@ function generateBatchCode(varietyId, year) {
 
 // GET /api/batches
 router.get('/', (req, res) => {
-  const { status, variety_id, location_id, season, year } = req.query;
+  const { status, variety_id, location_id, season, year, date_from, date_to } = req.query;
   let where = [];
   let params = [];
 
@@ -50,6 +50,8 @@ router.get('/', (req, res) => {
   if (location_id) { where.push('b.location_id = ?'); params.push(location_id); }
   if (season) { where.push('b.season = ?'); params.push(season); }
   if (year) { where.push('b.year = ?'); params.push(year); }
+  if (date_from) { where.push('b.planned_seed_date >= ?'); params.push(date_from); }
+  if (date_to) { where.push('b.planned_seed_date <= ?'); params.push(date_to); }
 
   const whereClause = where.length > 0 ? 'WHERE ' + where.join(' AND ') : '';
 

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -159,7 +159,7 @@ router.get('/calendar', (req, res) => {
 
 // Batches pages
 router.get('/batches', (req, res) => {
-  const { status, variety_id, location_id, season, year } = req.query;
+  const { status, variety_id, location_id, season, year, date_from, date_to } = req.query;
   let where = [];
   let params = [];
 
@@ -168,6 +168,8 @@ router.get('/batches', (req, res) => {
   if (location_id) { where.push('b.location_id = ?'); params.push(location_id); }
   if (season) { where.push('b.season = ?'); params.push(season); }
   if (year) { where.push('b.year = ?'); params.push(year); }
+  if (date_from) { where.push('b.planned_seed_date >= ?'); params.push(date_from); }
+  if (date_to) { where.push('b.planned_seed_date <= ?'); params.push(date_to); }
 
   const whereClause = where.length > 0 ? 'WHERE ' + where.join(' AND ') : '';
 
@@ -186,7 +188,7 @@ router.get('/batches', (req, res) => {
 
   res.render('batches/index', {
     batches, varieties, locations, statuses,
-    filters: { status, variety_id, location_id, season, year }
+    filters: { status, variety_id, location_id, season, year, date_from, date_to }
   });
 });
 

--- a/routes/varieties.js
+++ b/routes/varieties.js
@@ -21,7 +21,9 @@ router.get('/:id', (req, res) => {
 // POST /api/varieties
 router.post('/', (req, res) => {
   const { name, type, color, days_to_germination, days_to_transplant, days_to_bloom,
-          spacing_inches, light_requirement, pinch, notes } = req.body;
+          spacing_inches, light_requirement, pinch,
+          temperature_notes, light_notes, transplanting_notes, soil_notes, moisture_notes, tray_type_notes,
+          notes } = req.body;
 
   if (!name || !name.trim()) {
     return res.status(400).json({ error: 'Name is required' });
@@ -29,12 +31,17 @@ router.post('/', (req, res) => {
 
   const result = db.prepare(`
     INSERT INTO varieties (name, type, color, days_to_germination, days_to_transplant,
-      days_to_bloom, spacing_inches, light_requirement, pinch, notes)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      days_to_bloom, spacing_inches, light_requirement, pinch,
+      temperature_notes, light_notes, transplanting_notes, soil_notes, moisture_notes, tray_type_notes,
+      notes)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     name.trim(), type || null, color || null,
     days_to_germination || null, days_to_transplant || null, days_to_bloom || null,
-    spacing_inches || null, light_requirement || null, pinch ? 1 : 0, notes || null
+    spacing_inches || null, light_requirement || null, pinch ? 1 : 0,
+    temperature_notes || null, light_notes || null, transplanting_notes || null,
+    soil_notes || null, moisture_notes || null, tray_type_notes || null,
+    notes || null
   );
 
   res.status(201).json({ id: result.lastInsertRowid });
@@ -43,7 +50,9 @@ router.post('/', (req, res) => {
 // PUT /api/varieties/:id
 router.put('/:id', (req, res) => {
   const { name, type, color, days_to_germination, days_to_transplant, days_to_bloom,
-          spacing_inches, light_requirement, pinch, notes } = req.body;
+          spacing_inches, light_requirement, pinch,
+          temperature_notes, light_notes, transplanting_notes, soil_notes, moisture_notes, tray_type_notes,
+          notes } = req.body;
 
   if (!name || !name.trim()) {
     return res.status(400).json({ error: 'Name is required' });
@@ -55,13 +64,18 @@ router.put('/:id', (req, res) => {
   db.prepare(`
     UPDATE varieties SET name = ?, type = ?, color = ?, days_to_germination = ?,
       days_to_transplant = ?, days_to_bloom = ?, spacing_inches = ?,
-      light_requirement = ?, pinch = ?, notes = ?, updated_at = CURRENT_TIMESTAMP
+      light_requirement = ?, pinch = ?,
+      temperature_notes = ?, light_notes = ?, transplanting_notes = ?,
+      soil_notes = ?, moisture_notes = ?, tray_type_notes = ?,
+      notes = ?, updated_at = CURRENT_TIMESTAMP
     WHERE id = ?
   `).run(
     name.trim(), type || null, color || null,
     days_to_germination || null, days_to_transplant || null, days_to_bloom || null,
-    spacing_inches || null, light_requirement || null, pinch ? 1 : 0, notes || null,
-    req.params.id
+    spacing_inches || null, light_requirement || null, pinch ? 1 : 0,
+    temperature_notes || null, light_notes || null, transplanting_notes || null,
+    soil_notes || null, moisture_notes || null, tray_type_notes || null,
+    notes || null, req.params.id
   );
 
   res.json({ success: true });

--- a/views/batches/index.ejs
+++ b/views/batches/index.ejs
@@ -15,7 +15,7 @@
       </button>
     <% }) %>
   </div>
-  <div class="flex flex-wrap gap-2">
+  <div class="flex flex-wrap gap-2 items-center">
     <select onchange="updateFilters('variety_id', this.value)" class="form-input w-auto text-sm">
       <option value="">All Varieties</option>
       <% varieties.forEach(v => { %>
@@ -28,6 +28,14 @@
         <option value="<%= l.id %>" <%= filters.location_id == l.id ? 'selected' : '' %>><%= l.name %></option>
       <% }) %>
     </select>
+    <span class="text-sm text-gray-500 ml-1">Seed date:</span>
+    <input type="date" class="form-input w-auto text-sm"
+           value="<%= filters.date_from || '' %>"
+           onchange="updateFilters('date_from', this.value)">
+    <span class="text-sm text-gray-500">to</span>
+    <input type="date" class="form-input w-auto text-sm"
+           value="<%= filters.date_to || '' %>"
+           onchange="updateFilters('date_to', this.value)">
   </div>
 </div>
 
@@ -35,7 +43,7 @@
   <div class="empty-state">
     <div class="empty-state-icon">&#127793;</div>
     <p class="text-lg font-medium text-gray-600 mb-2">No batches found</p>
-    <% if (filters.status || filters.variety_id || filters.location_id) { %>
+    <% if (filters.status || filters.variety_id || filters.location_id || filters.date_from || filters.date_to) { %>
       <p class="mb-4">Try clearing your filters.</p>
       <a href="/batches" class="btn btn-secondary">Clear Filters</a>
     <% } else { %>

--- a/views/varieties/form.ejs
+++ b/views/varieties/form.ejs
@@ -73,6 +73,34 @@
       <label for="pinch" class="text-sm text-gray-700">Pinch this variety</label>
     </div>
 
+    <fieldset class="border border-gray-200 rounded-lg p-4 space-y-4">
+      <legend class="text-sm font-semibold text-gray-700 px-2">Growing Notes</legend>
+      <div>
+        <label class="form-label" for="temperature_notes">Temperature Needs</label>
+        <textarea id="temperature_notes" name="temperature_notes" rows="2" class="form-input"><%= variety ? variety.temperature_notes || '' : '' %></textarea>
+      </div>
+      <div>
+        <label class="form-label" for="light_notes">Light Needs</label>
+        <textarea id="light_notes" name="light_notes" rows="2" class="form-input"><%= variety ? variety.light_notes || '' : '' %></textarea>
+      </div>
+      <div>
+        <label class="form-label" for="transplanting_notes">Transplanting Guide</label>
+        <textarea id="transplanting_notes" name="transplanting_notes" rows="2" class="form-input"><%= variety ? variety.transplanting_notes || '' : '' %></textarea>
+      </div>
+      <div>
+        <label class="form-label" for="soil_notes">Soil Needs</label>
+        <textarea id="soil_notes" name="soil_notes" rows="2" class="form-input"><%= variety ? variety.soil_notes || '' : '' %></textarea>
+      </div>
+      <div>
+        <label class="form-label" for="moisture_notes">Moisture Needs</label>
+        <textarea id="moisture_notes" name="moisture_notes" rows="2" class="form-input"><%= variety ? variety.moisture_notes || '' : '' %></textarea>
+      </div>
+      <div>
+        <label class="form-label" for="tray_type_notes">Tray Types</label>
+        <textarea id="tray_type_notes" name="tray_type_notes" rows="2" class="form-input"><%= variety ? variety.tray_type_notes || '' : '' %></textarea>
+      </div>
+    </fieldset>
+
     <div>
       <label class="form-label" for="notes">Notes</label>
       <textarea id="notes" name="notes" rows="3" class="form-input"><%= variety ? variety.notes || '' : '' %></textarea>
@@ -99,6 +127,12 @@ document.getElementById('variety-form').addEventListener('submit', async (e) => 
     spacing_inches: form.spacing_inches.value ? parseInt(form.spacing_inches.value) : null,
     light_requirement: form.light_requirement.value,
     pinch: form.pinch.checked ? 1 : 0,
+    temperature_notes: form.temperature_notes.value,
+    light_notes: form.light_notes.value,
+    transplanting_notes: form.transplanting_notes.value,
+    soil_notes: form.soil_notes.value,
+    moisture_notes: form.moisture_notes.value,
+    tray_type_notes: form.tray_type_notes.value,
     notes: form.notes.value
   };
 


### PR DESCRIPTION
## Summary
- Add 6 structured growing notes fields (temperature, light, transplanting, soil, moisture, tray types) to varieties with migration support for existing databases
- Add date range filters (from/to on planned seed date) to the batches screen alongside existing variety and location dropdowns

## Test plan
- [ ] Start the app with an existing database — migration should add new columns without errors
- [ ] Edit a variety — new Growing Notes section appears with 6 textareas, saves correctly
- [ ] Create a new variety with growing notes — values persist after save
- [ ] On the Batches screen, set a "from" date — only batches with planned seed date on or after that date appear
- [ ] Set both "from" and "to" dates — batches outside the range are excluded
- [ ] Clear date inputs — filter is removed and all batches show again
- [ ] Delete the database and restart — fresh schema includes new columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)