### PR TITLE
Fix timeline dot misalignment

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -57,7 +57,7 @@
 /* Timeline */
 .timeline-track {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0;
   overflow-x: auto;
   padding: 1rem 0;


### PR DESCRIPTION
## Summary
- Fix lifecycle timeline dots and connecting lines being vertically misaligned when some steps have dates and others don't

## Root cause
`.timeline-track` used `align-items: center`, which vertically centers each step in the row. Steps with a date label are taller than those without, so shorter steps got pushed down — misaligning their dots and connecting lines relative to taller steps.

## Fix
Changed to `align-items: flex-start` so all steps anchor to the same top edge regardless of height.

Fixes #2

## Test plan
- [x] View a batch detail page where some milestones have dates and others don't — dots and connecting line should be horizontally aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)